### PR TITLE
all-feedstocks info documentation

### DIFF
--- a/source/utils.rst
+++ b/source/utils.rst
@@ -17,7 +17,7 @@ Here is a list of current functioning utilties:
 
 * all-feedstocks
   
-  * Clone/List all available feedstock repositories
+  * Clone/List all available feedstock repositories and get info from them
 
 ============
 Installation
@@ -180,6 +180,13 @@ To clone all feedstocks belonging to a GitHub organization, use:
 
 This will clone all feedstocks to the :bash:`feedstocks/` directory in your current working directory.
 
+To get information about Git and version information from currently cloned feedstock repos, use:
+
+.. code-block:: bash
+
+    $ all-feedstocks info
+
+
 For more information on possible usage:
 
 .. code-block:: bash
@@ -187,3 +194,4 @@ For more information on possible usage:
     $ all-feedstocks -h
     $ all-feedstocks list -h
     $ all-feedstocks clone -h
+    $ all-feedstocks info -h


### PR DESCRIPTION
Documentation detailing `nsls2forge_utils`'s `all-feedstocks info` command and how to use it.

Merge when the PR found [here](https://github.com/nsls-ii-forge/nsls2forge-utils/pull/18) is merged.