### PR TITLE
document method to calculate SHA256 digest

### DIFF
--- a/source/creating_packages.rst
+++ b/source/creating_packages.rst
@@ -217,14 +217,32 @@ or download ``meta.yaml`` from a known URL:
 
 Open and edit the ``meta.yaml`` file.
 
-Generate SHA256 digest
-----------------------
-When manually creating a recipe it will be necessary to calculate the SHA256
-digest of the tar.gz. The recommended method is to use ``openssl``. For example:
+SHA256 digest
+-------------
+When manually creating a recipe it will be necessary to find or calculate the
+SHA256 digest of the ``<package>.tar.gz`` file. If the package has been released on
+PyPI then the SHA256 digest of the associated ``<package>.tar.gz`` file can be found
+directly on PyPI without the need to calculate it. Set ``source: url:`` in ``meta.yml``
+to the PyPI download link.
+
+If the package has not been released on PyPI a ``<package>.tar.gz`` file may be
+available from GitHub or a similar online source code repository. In this case
+download the ``<package>.tar.gz`` file and calculate its SHA256 digest. The
+recommended method is to use ``openssl``.
+For example,
 
 .. code-block:: bash
 
-    openssl sha256 bluesky-1.6.6.tar.gz
+    wget https://github.com/bluesky/bluesky/archive/v1.6.6.tar.gz
+
+    openssl sha256 v1.6.6.tar.gz
+
+Use the download link from the source code repository for ``source: url:`` in ``meta.yml``.
+
+.. note::
+
+    The ``<package>.tar.gz`` file on PyPI will not have the same SHA256 digest as the
+    ``<package>.tar.gz`` file downloaded from a source code repository such as GitHub.
 
 ====================
 Prepare recipe files

--- a/source/creating_packages.rst
+++ b/source/creating_packages.rst
@@ -217,6 +217,15 @@ or download ``meta.yaml`` from a known URL:
 
 Open and edit the ``meta.yaml`` file.
 
+Generate SHA256 digest
+----------------------
+When manually creating a recipe it will be necessary to calculate the SHA256
+digest of the tar.gz. The recommended method is to use ``openssl``. For example:
+
+.. code-block:: bash
+
+    openssl sha256 bluesky-1.6.6.tar.gz
+
 ====================
 Prepare recipe files
 ====================


### PR DESCRIPTION
This PR adds instructions for calculating SHA256 digest required for a recipe. Closes #5.

Here is what this PR looks like:


![nsls-ii-docs-sha256](https://user-images.githubusercontent.com/4492613/91604981-ae040f80-e93d-11ea-988d-6d09cf7b9f4a.png)
